### PR TITLE
Update simple_calendar.py

### DIFF
--- a/aiogram_calendar/simple_calendar.py
+++ b/aiogram_calendar/simple_calendar.py
@@ -1,4 +1,5 @@
 import calendar
+from contextlib import suppress
 from datetime import datetime, timedelta
 import locale
 locale.setlocale(locale.LC_TIME, 'ru_RU.UTF-8')
@@ -6,6 +7,7 @@ locale.setlocale(locale.LC_TIME, 'ru_RU.UTF-8')
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from aiogram.utils.callback_data import CallbackData
 from aiogram.types import CallbackQuery
+from aiogram.utils.exceptions import MessageNotModified
 
 
 search_cb = CallbackData('search', 'action')
@@ -137,7 +139,14 @@ class SimpleCalendar:
             await query.message.edit_reply_markup(await self.start_calendar(int(next_date.year), int(next_date.month)))
         if data['act'] == "CURR-MONTH":
             next_date = datetime.now()
-            await query.message.edit_reply_markup(await self.start_calendar(int(next_date.year), int(next_date.month)))
+            with suppress(MessageNotModified):
+                await query.answer()
+                await query.message.edit_reply_markup(
+                        await self.start_calendar(
+                            int(next_date.year),
+                            int(next_date.month))
+                        )
+
 
         # at some point user clicks DAY button, returning date
         return return_data


### PR DESCRIPTION
added come functionality to simple calendar
I'm developer from Russia and I decided that it will be great to add some local functionality to other people from other countries that helps to faster localize it's apps.
Added button "Cancel" for canceling operation. And added button "Today" to return in current month if user decided to return to today's calendar view.
Added visual selection of current day in calendar

![cal](https://user-images.githubusercontent.com/41025164/146032184-e038c5d8-4bac-4160-b987-728697495f05.png)

Example of cancel button
```python
# example_bot.py
@dp.callback_query_handler(cancel_callback.filter())
async def cancel_action(callback_query: CallbackQuery, callback_data: dict):
    await callback_query.message.edit_text('You canceled action')
    await callback_query.answer()
```
Hope it will helps to other developers